### PR TITLE
Fix error when _still_image_url failed

### DIFF
--- a/custom_components/yi_hack/camera.py
+++ b/custom_components/yi_hack/camera.py
@@ -229,9 +229,7 @@ class YiHackCamera(Camera):
                     ffmpeg.get_image(
                         stream_source,
                         output_format=IMAGE_JPEG,
-                        extra_cmd=self._extra_arguments,
-                        width=width,
-                        height=height
+                        extra_cmd=self._extra_arguments
                     )
                 )
 


### PR DESCRIPTION
Error log in hass:

  File "/config/custom_components/yi_hack/camera.py", line 228, in async_camera_image
    ffmpeg.get_image(
TypeError: get_image() got an unexpected keyword argument 'width'