### PR TITLE
add move_to_preset service (tested on sonoff_hack firmware only)

### DIFF
--- a/custom_components/yi_hack/services.yaml
+++ b/custom_components/yi_hack/services.yaml
@@ -36,6 +36,30 @@ ptz:
           unit_of_measurement: "s"
           mode: box
 
+move_to_preset:
+  name: Move to a preset
+  description: Aim camera at the defined preset
+  fields:
+    entity_id:
+      name: Entity id
+      description: Name of entity to move.
+      required: true
+      example: "camera.living_room_camera"
+      selector:
+        entity:
+          integration: yi_hack
+          domain: camera
+    preset_id:
+      name: Preset id
+      description: "Id of the preset to go to"
+      required: true
+      example: 0
+      selector:
+        number:
+          min: 0
+          max: 14
+          mode: box
+
 speak:
   name: speak
   description: TTS service for yi-hack camera.


### PR DESCRIPTION
Basic implementation of `move_to_preset service`.
As I only own a sonoff camera, it was only tested on sonoff_hack firmware.
It seems that preset.sh is also supported on other firmware, but I'm not sure that the extreme values are the same (0 to 14 for preset_id).