### PR TITLE
Add link to Camera setup page from the HA device page

### DIFF
--- a/custom_components/yi_hack/camera.py
+++ b/custom_components/yi_hack/camera.py
@@ -366,6 +366,7 @@ class YiHackCamera(Camera):
             "identifiers": {(DOMAIN, self._mac)},
             "manufacturer": DEFAULT_BRAND,
             "model": DOMAIN,
+            "configuration_url": self._http_base_url,
         }
 
 class YiHackMqttCamera(Camera):


### PR DESCRIPTION
Adding the `configuration_url` attribute to the device-register for the camera allows us to have the link `"Visit device"` straight from the HA Integration device page:

![image](https://user-images.githubusercontent.com/12975783/162645121-68e2e5f0-319e-4786-a188-a1372eccd382.png)
