### PR TITLE
bugfix: fix an issue with python 3.9, remove a warning from hass

### DIFF
--- a/custom_components/yi_hack/media_player.py
+++ b/custom_components/yi_hack/media_player.py
@@ -1,4 +1,5 @@
 """Support for output tts to the yi-hack cam."""
+from __future__ import annotations
 
 import asyncio
 import logging

--- a/custom_components/yi_hack/media_source.py
+++ b/custom_components/yi_hack/media_source.py
@@ -68,7 +68,7 @@ class YiHackMediaSource(MediaSource):
         entry_id, event_dir, event_file = async_parse_identifier(item)
 
         if len(self._devices) == 0:
-            device_registry = await self.hass.helpers.device_registry.async_get_registry()
+            device_registry = self.hass.helpers.device_registry.async_get(self.hass)
             for device in device_registry.devices.values():
                 if device.identifiers is not None:
                     try:


### PR DESCRIPTION
tested with: hass 2022.11.2 and Python 3.9.14.