### PR TITLE
Enhance entity naming (similar to HA native entity naming)

### DIFF
--- a/custom_components/yi_hack/binary_sensor.py
+++ b/custom_components/yi_hack/binary_sensor.py
@@ -30,39 +30,39 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry, async_add_
     """Set up MQTT motion sensors."""
     if (config.data[CONF_HACK_NAME] == DEFAULT_BRAND) or (config.data[CONF_HACK_NAME] == MSTAR):
         entities = [
-            YiMQTTBinarySensor(config, "status"),
-            YiMQTTBinarySensor(config, "motion_detection"),
-            YiMQTTBinarySensor(config, "baby_crying"),
+            YiMQTTBinarySensor(config, "status", "Status"),
+            YiMQTTBinarySensor(config, "motion_detection", "Motion Detection"),
+            YiMQTTBinarySensor(config, "baby_crying", "Baby Crying"),
         ]
     elif (config.data[CONF_HACK_NAME] == V5):
         entities = [
-            YiMQTTBinarySensor(config, "status"),
-            YiMQTTBinarySensor(config, "motion_detection"),
-            YiMQTTBinarySensor(config, "sound_detection"),
-            YiMQTTBinarySensor(config, "baby_crying"),
+            YiMQTTBinarySensor(config, "status", "Status"),
+            YiMQTTBinarySensor(config, "motion_detection", "Motion Detection"),
+            YiMQTTBinarySensor(config, "sound_detection", "Sound Detection"),
+            YiMQTTBinarySensor(config, "baby_crying", "Baby Crying"),
         ]
     elif (config.data[CONF_HACK_NAME] == ALLWINNER):
         entities = [
-            YiMQTTBinarySensor(config, "status"),
-            YiMQTTBinarySensor(config, "motion_detection"),
-            YiMQTTBinarySensor(config, "human_detection"),
-            YiMQTTBinarySensor(config, "vehicle_detection"),
-            YiMQTTBinarySensor(config, "animal_detection"),
-            YiMQTTBinarySensor(config, "sound_detection"),
+            YiMQTTBinarySensor(config, "status", "Status"),
+            YiMQTTBinarySensor(config, "motion_detection", "Motion Detection"),
+            YiMQTTBinarySensor(config, "human_detection", "Human Detection"),
+            YiMQTTBinarySensor(config, "vehicle_detection", "Vehicle Detection"),
+            YiMQTTBinarySensor(config, "animal_detection", "Animal Detection"),
+            YiMQTTBinarySensor(config, "sound_detection", "Sound Detection"),
         ]
     elif (config.data[CONF_HACK_NAME] == ALLWINNERV2):
         entities = [
-            YiMQTTBinarySensor(config, "status"),
-            YiMQTTBinarySensor(config, "motion_detection"),
-            YiMQTTBinarySensor(config, "human_detection"),
-            YiMQTTBinarySensor(config, "vehicle_detection"),
-            YiMQTTBinarySensor(config, "animal_detection"),
-            YiMQTTBinarySensor(config, "sound_detection"),
+            YiMQTTBinarySensor(config, "status", "Status"),
+            YiMQTTBinarySensor(config, "motion_detection", "Motion Detection"),
+            YiMQTTBinarySensor(config, "human_detection", "Human Detection"),
+            YiMQTTBinarySensor(config, "vehicle_detection", "Vehicle Detection"),
+            YiMQTTBinarySensor(config, "animal_detection", "Animal Detection"),
+            YiMQTTBinarySensor(config, "sound_detection", "Sound Detection"),
         ]
     elif config.data[CONF_HACK_NAME] == SONOFF:
         entities = [
-            YiMQTTBinarySensor(config, "status"),
-            YiMQTTBinarySensor(config, "motion_detection"),
+            YiMQTTBinarySensor(config, "status", "Status"),
+            YiMQTTBinarySensor(config, "motion_detection", "Motion Detection"),
         ]
 
     async_add_entities(entities)
@@ -71,11 +71,11 @@ async def async_setup_entry(hass: HomeAssistant, config: ConfigEntry, async_add_
 class YiMQTTBinarySensor(BinarySensorEntity):
     """Representation of a motion detection sensor that is updated via MQTT."""
 
-    def __init__(self, config: ConfigEntry, sensor_type):
+    def __init__(self, config: ConfigEntry, sensor_type, name):
         """Initialize the sensor."""
         self._state = False
         self._device_name = config.data[CONF_NAME]
-        self._name = self._device_name + "_" + sensor_type
+        self._name = self._device_name + " " + name
         self._mac = config.data[CONF_MAC]
         self._mqtt_subscription = None
         self._delay_listener = None

--- a/custom_components/yi_hack/camera.py
+++ b/custom_components/yi_hack/camera.py
@@ -116,7 +116,7 @@ class YiHackCamera(Camera):
         self._extra_arguments = config.data[CONF_EXTRA_ARGUMENTS]
         self._manager = hass.data[DATA_FFMPEG]
         self._device_name = config.data[CONF_NAME]
-        self._name = self._device_name + "_cam"
+        self._name = self._device_name + " " + "Cam"
         self._unique_id = self._device_name + "_caca"
         self._mac = config.data[CONF_MAC]
         self._host = config.data[CONF_HOST]
@@ -436,7 +436,7 @@ class YiHackMqttCamera(Camera):
         super().__init__()
 
         self._device_name = config.data[CONF_NAME]
-        self._name = self._device_name  + "_motion_detection_cam"
+        self._name = self._device_name + " " + "Motion Detection Cam"
         self._unique_id = self._device_name + "_camd"
         self._mac = config.data[CONF_MAC]
         self._host = config.data[CONF_HOST]

--- a/custom_components/yi_hack/media_player.py
+++ b/custom_components/yi_hack/media_player.py
@@ -66,7 +66,7 @@ class YiHackMediaPlayer(MediaPlayerEntity):
     def __init__(self, config):
         """Initialize the device."""
         self._device_name = config.data[CONF_NAME]
-        self._name = self._device_name + "_media_player"
+        self._name = self._device_name + " " + "Media Player"
         self._unique_id = self._device_name + "_mpca"
         self._mac = config.data[CONF_MAC]
         self._host = config.data[CONF_HOST]

--- a/custom_components/yi_hack/select.py
+++ b/custom_components/yi_hack/select.py
@@ -17,19 +17,19 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     if config_entry.data[CONF_HACK_NAME] == SONOFF:
         entities = [
-            YiHackSelect(hass, config_entry, "sensitivity", [ "low", "medium", "high" ]),
-            YiHackSelect(hass, config_entry, "ir", [ "auto", "on", "off" ]),
+            YiHackSelect(hass, config_entry, "sensitivity", "Sensitivity", [ "low", "medium", "high" ]),
+            YiHackSelect(hass, config_entry, "ir", "IR", [ "auto", "on", "off" ]),
         ]
     elif config_entry.data[CONF_HACK_NAME] == V5:
         entities = [
-            YiHackSelect(hass, config_entry, "sensitivity", [ "low", "medium", "high" ]),
-            YiHackSelect(hass, config_entry, "sound_sensitivity", [ "30", "35", "40", "45", "50", "60", "70", "80", "90" ]),
+            YiHackSelect(hass, config_entry, "sensitivity", "Sensitivity", [ "low", "medium", "high" ]),
+            YiHackSelect(hass, config_entry, "sound_sensitivity", "Sound Sensitivity", [ "30", "35", "40", "45", "50", "60", "70", "80", "90" ]),
         ]
     else:
         entities = [
-            YiHackSelect(hass, config_entry, "sensitivity", [ "low", "medium", "high" ]),
-            YiHackSelect(hass, config_entry, "sound_sensitivity", [ "30", "35", "40", "45", "50", "60", "70", "80", "90" ]),
-            YiHackSelect(hass, config_entry, "cruise", [ "no", "presets", "360" ]),
+            YiHackSelect(hass, config_entry, "sensitivity", "Sensitivity", [ "low", "medium", "high" ]),
+            YiHackSelect(hass, config_entry, "sound_sensitivity", "Sound Sensitivity", [ "30", "35", "40", "45", "50", "60", "70", "80", "90" ]),
+            YiHackSelect(hass, config_entry, "cruise", "Cruise", [ "no", "presets", "360" ]),
         ]
 
     async_add_entities(entities)
@@ -38,11 +38,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class YiHackSelect(SelectEntity):
     """Select entity."""
 
-    def __init__(self, hass, config, select_type, select_options):
+    def __init__(self, hass, config, select_type, name, select_options):
         """Initialize entity."""
         self._device_name = config.data[CONF_NAME]
         self._mac = config.data[CONF_MAC]
-        self._name = self._device_name + "_select_" + select_type
+        self._name = self._device_name + " " + name
         self._mqtt_cmnd_topic = config.data[CONF_MQTT_PREFIX] + "/cmnd/camera/" + select_type
         self._mqtt_stat_topic = config.data[CONF_MQTT_PREFIX] + "/stat/camera/" + select_type
         self._select_type = select_type

--- a/custom_components/yi_hack/switch.py
+++ b/custom_components/yi_hack/switch.py
@@ -19,58 +19,58 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Yi Camera switches from a config entry."""
     if (config_entry.data[CONF_HACK_NAME] == DEFAULT_BRAND) or (config_entry.data[CONF_HACK_NAME] == MSTAR):
         entities = [
-            YiHackSwitch(hass, config_entry, "switch_on"),
-            YiHackSwitch(hass, config_entry, "save_video_on_motion"),
-            YiHackSwitch(hass, config_entry, "baby_crying_detect"),
-            YiHackSwitch(hass, config_entry, "led"),
-            YiHackSwitch(hass, config_entry, "ir"),
-            YiHackSwitch(hass, config_entry, "rotate"),
+            YiHackSwitch(hass, config_entry, "switch_on", "Switch On"),
+            YiHackSwitch(hass, config_entry, "save_video_on_motion", "Save Video on Motion"),
+            YiHackSwitch(hass, config_entry, "baby_crying_detect", "Baby Crying Detect"),
+            YiHackSwitch(hass, config_entry, "led", "LED"),
+            YiHackSwitch(hass, config_entry, "ir", "IR"),
+            YiHackSwitch(hass, config_entry, "rotate", "Rotate"),
         ]
     elif (config_entry.data[CONF_HACK_NAME] == V5):
         entities = [
-            YiHackSwitch(hass, config_entry, "switch_on"),
-#            YiHackSwitch(hass, config_entry, "detect_motion"),
-            YiHackSwitch(hass, config_entry, "save_video_on_motion"),
-            YiHackSwitch(hass, config_entry, "sound_detection"),
-            YiHackSwitch(hass, config_entry, "baby_crying_detect"),
-            YiHackSwitch(hass, config_entry, "led"),
-            YiHackSwitch(hass, config_entry, "ir"),
-            YiHackSwitch(hass, config_entry, "rotate"),
+            YiHackSwitch(hass, config_entry, "switch_on", "Switch"),
+#            YiHackSwitch(hass, config_entry, "detect_motion", "Detect Motion"),
+            YiHackSwitch(hass, config_entry, "save_video_on_motion", "Save Video on Motion"),
+            YiHackSwitch(hass, config_entry, "sound_detection", "Sound Detection"),
+            YiHackSwitch(hass, config_entry, "baby_crying_detect", "Baby Crying Detect"),
+            YiHackSwitch(hass, config_entry, "led", "LED"),
+            YiHackSwitch(hass, config_entry, "ir", "IR"),
+            YiHackSwitch(hass, config_entry, "rotate", "Rotate"),
         ]
     elif (config_entry.data[CONF_HACK_NAME] == ALLWINNER):
         entities = [
-            YiHackSwitch(hass, config_entry, "switch_on"),
-            YiHackSwitch(hass, config_entry, "motion_detection"),
-            YiHackSwitch(hass, config_entry, "save_video_on_motion"),
-            YiHackSwitch(hass, config_entry, "ai_human_detection"),
-            YiHackSwitch(hass, config_entry, "ai_vehicle_detection"),
-            YiHackSwitch(hass, config_entry, "ai_animal_detection"),
-            YiHackSwitch(hass, config_entry, "sound_detection"),
-            YiHackSwitch(hass, config_entry, "led"),
-            YiHackSwitch(hass, config_entry, "ir"),
-            YiHackSwitch(hass, config_entry, "rotate"),
+            YiHackSwitch(hass, config_entry, "switch_on", "Switch On"),
+            YiHackSwitch(hass, config_entry, "motion_detection", "Motion Detection"),
+            YiHackSwitch(hass, config_entry, "save_video_on_motion", "Save Video on Motion"),
+            YiHackSwitch(hass, config_entry, "ai_human_detection", "AI Human Detection"),
+            YiHackSwitch(hass, config_entry, "ai_vehicle_detection", "AI Vehicle Detection"),
+            YiHackSwitch(hass, config_entry, "ai_animal_detection", "AI Animal Detection"),
+            YiHackSwitch(hass, config_entry, "sound_detection", "Sound Detection"),
+            YiHackSwitch(hass, config_entry, "led", "LED"),
+            YiHackSwitch(hass, config_entry, "ir", "IR"),
+            YiHackSwitch(hass, config_entry, "rotate", "Rotate"),
         ]
     elif (config_entry.data[CONF_HACK_NAME] == ALLWINNERV2):
         entities = [
-            YiHackSwitch(hass, config_entry, "switch_on"),
-            YiHackSwitch(hass, config_entry, "motion_detection"),
-            YiHackSwitch(hass, config_entry, "save_video_on_motion"),
-            YiHackSwitch(hass, config_entry, "ai_human_detection"),
-            YiHackSwitch(hass, config_entry, "ai_vehicle_detection"),
-            YiHackSwitch(hass, config_entry, "ai_animal_detection"),
-            YiHackSwitch(hass, config_entry, "face_detection"),
-            YiHackSwitch(hass, config_entry, "motion_tracking"),
-            YiHackSwitch(hass, config_entry, "sound_detection"),
-            YiHackSwitch(hass, config_entry, "led"),
-            YiHackSwitch(hass, config_entry, "ir"),
-            YiHackSwitch(hass, config_entry, "rotate"),
+            YiHackSwitch(hass, config_entry, "switch_on", "Switch"),
+            YiHackSwitch(hass, config_entry, "motion_detection", "Motion Detection"),
+            YiHackSwitch(hass, config_entry, "save_video_on_motion", "Save Video on Motion"),
+            YiHackSwitch(hass, config_entry, "ai_human_detection", "AI Human Detection"),
+            YiHackSwitch(hass, config_entry, "ai_vehicle_detection", "AI Vehicle Detection"),
+            YiHackSwitch(hass, config_entry, "ai_animal_detection", "AI Animal Detection"),
+            YiHackSwitch(hass, config_entry, "face_detection", "Face Detection"),
+            YiHackSwitch(hass, config_entry, "motion_tracking", "Motion Tracking"),
+            YiHackSwitch(hass, config_entry, "sound_detection", "Sound Detection"),
+            YiHackSwitch(hass, config_entry, "led", "LED"),
+            YiHackSwitch(hass, config_entry, "ir", "IR"),
+            YiHackSwitch(hass, config_entry, "rotate", "Rotate"),
         ]
     elif config_entry.data[CONF_HACK_NAME] == SONOFF:
         entities = [
-            YiHackSwitch(hass, config_entry, "switch_on"),
-            YiHackSwitch(hass, config_entry, "motion_detection"),
-            YiHackSwitch(hass, config_entry, "local_record"),
-            YiHackSwitch(hass, config_entry, "rotate"),
+            YiHackSwitch(hass, config_entry, "switch_on", "Switch on"),
+            YiHackSwitch(hass, config_entry, "motion_detection", "Motion Detection"),
+            YiHackSwitch(hass, config_entry, "local_record", "Local Record"),
+            YiHackSwitch(hass, config_entry, "rotate", "Rotate"),
         ]
 
     async_add_entities(entities)
@@ -78,7 +78,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class YiHackSwitch(SwitchEntity):
     """Representation of a Yi Camera Switch."""
 
-    def __init__(self, hass, config, switch_type):
+    def __init__(self, hass, config, switch_type, name):
         """Initialize the device."""
         self._device_name = config.data[CONF_NAME]
         self._mac = config.data[CONF_MAC]
@@ -87,7 +87,7 @@ class YiHackSwitch(SwitchEntity):
         self._user = config.data[CONF_USERNAME]
         self._password = config.data[CONF_PASSWORD]
         self._switch_type = switch_type
-        self._name = self._device_name + "_switch_" + switch_type
+        self._name = self._device_name + " " + name
         self._mqtt_subscription = None
         self._mqtt_cmnd_topic = config.data[CONF_MQTT_PREFIX] + "/cmnd/camera/" + switch_type
         self._mqtt_stat_topic = config.data[CONF_MQTT_PREFIX] + "/stat/camera/" + switch_type


### PR DESCRIPTION
This PR sets custom names for all the entities.

Before:
![23 11 26_16-14-44_AYqed](https://github.com/roleoroleo/yi-hack_ha_integration/assets/1368405/c1f54328-4d4e-4ec7-bc17-04559cfdc954)


After:
![23 11 26_16-17-28_QBvNk](https://github.com/roleoroleo/yi-hack_ha_integration/assets/1368405/0b051d9c-e420-4a0c-93f9-588f480c4016)

Home Assistant will hide the device name in the entity name. Renaming the device will also work and will update the entity IDs. This change should bring the entity ids of this integration to work similar like native HA integration naming schema. 

As you can see in this example, I renamed the device to Yi Home and this is the result of HAs automatic entity renaming:
![image](https://github.com/roleoroleo/yi-hack_ha_integration/assets/1368405/20e03329-196f-4b19-8420-2793303cda99)
