### PR TITLE
Fix media source error in HA 2024.6.3

### DIFF
--- a/custom_components/yi_hack/media_source.py
+++ b/custom_components/yi_hack/media_source.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
     CONF_USERNAME
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 
 from .const import DEFAULT_BRAND, DOMAIN, HTTP_TIMEOUT
 
@@ -68,7 +69,7 @@ class YiHackMediaSource(MediaSource):
         entry_id, event_dir, event_file = async_parse_identifier(item)
 
         if len(self._devices) == 0:
-            device_registry = self.hass.helpers.device_registry.async_get(self.hass)
+            device_registry = dr.async_get(self.hass)
             for device in device_registry.devices.values():
                 if device.identifiers is not None:
                     try:


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/decorators.py", line 27, in _handle_async_response
    await func(hass, connection, msg)
  File "/usr/src/homeassistant/homeassistant/components/media_source/__init__.py", line 187, in websocket_browse_media
    media = await async_browse_media(hass, msg.get("media_content_id", ""))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/media_source/__init__.py", line 135, in async_browse_media
    item = await _get_media_item(hass, media_content_id, None).async_browse()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/media_source/models.py", line 80, in async_browse
    return await self.async_media_source().async_browse_media(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/yi_hack/media_source.py", line 71, in async_browse_media
    device_registry = self.hass.helpers.device_registry.async_get(self.hass)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: async_get() takes 1 positional argument but 2 were given