### PR TITLE
README: document that MQTT prefix and client id must be unique per camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@ If you configure motion detection in your camera and media source in your home a
    - MQTT enabled
    - Configured with MQTT Broker credentials
    - Default Topics configuration
+   - A unique topic prefix and client id, if you have more than one camera (see [Multiple cameras](#multiple-cameras))
+
+## Multiple cameras
+Every camera ships with the same MQTT defaults (`MQTT_PREFIX` = `yicam`, `MQTT_CLIENT_ID` = `yi-cam`).
+If you have more than one camera, these two settings **must be unique per camera**:
+- `MQTT_PREFIX` - unique, and flat: a prefix containing `/` adds a nested topic level and does not work
+- `MQTT_CLIENT_ID` - unique
+
+Leave the topic names themselves at their defaults (`TOPIC_BIRTH_WILL`, `TOPIC_MOTION`,
+`TOPIC_MOTION_IMAGE`, `TOPIC_MOTION_FILES`, `TOPIC_SOUND_DETECTION`).
+"Default Topics configuration" above refers to those names, not to the prefix: the
+integration reads the prefix from the camera when the entry is set up.
+
+If the defaults are left in place on a second camera, two things go wrong:
+1. MQTT brokers enforce client id uniqueness by disconnecting the existing session, so the cameras repeatedly disconnect each other.
+2. Both cameras publish to the same topics, so motion events and snapshots from one camera appear on the other (see #62 and #91).
 
 ## Installation
 **(1)** Copy the  `custom_components` folder your configuration directory.


### PR DESCRIPTION
As requested in #91.

Every camera ships with the same MQTT defaults (`MQTT_PREFIX` = `yicam`, `MQTT_CLIENT_ID` = `yi-cam`). The existing `Default Topics configuration` requirement reads, on a second camera, as an instruction to leave those in place — which produces the two failures reported in #62 and #91:

1. Brokers enforce client-id uniqueness by disconnecting the existing session, so the cameras repeatedly disconnect each other.
2. Both cameras publish to the same topics, so motion events and snapshots from one camera appear on the other.

This adds a short **Multiple cameras** section stating that `MQTT_PREFIX` and `MQTT_CLIENT_ID` must be unique, clarifies that "Default Topics configuration" refers to the topic *names* rather than the prefix, and notes that the prefix must be flat (a prefix containing `/` adds a nested topic level and did not work for me).

Docs only — no code changes.

Verified on two cameras against one broker (yi-hack-Allwinner-v2 `r35gb` and yi-hack-MStar `y30`): with `yicam`/`yi-cam` on the first and `yicam_domex`/`yi-cam-domex` on the second, both hold their own retained `<prefix>/status = online` simultaneously and appear as separate devices in Home Assistant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
